### PR TITLE
Update extensions_lib_subr.conf

### DIFF
--- a/dialplan/asterisk/extensions_lib_subr.conf
+++ b/dialplan/asterisk/extensions_lib_subr.conf
@@ -152,7 +152,7 @@ exten = application:directory,1,Gosub(xivo-pickup,0,1)
 same  =                       n,Directory(${XIVO_FWD_ACTIONARG1})
 same  =                       n,Hangup()
 
-exten = application:faxtomail,1,Set(XIVO_FAXFILENAME=${XIVO_SRCNUM}-${EPOCH})
+exten = application:faxtomail,1,Set(XIVO_FAXFILENAME=${XIVO_DSTNUM}-${XIVO_SRCNUM}-${EPOCH})
 same  =                       n,Set(XIVO_FAXEMAIL=${XIVO_FWD_ACTIONARG1})
 same  =                       n,Gosub(rxfax,s,1)
 


### PR DESCRIPTION
This a feature request from many customers. The need is this integration of the destination number in the fax file naming.

In case of Fax to FTP, if the FTP repository is unavailable all the pending fax are mixed into the /var/spool/asterisk/fax. With this new naming you are able to retrieve the destination of each fax.